### PR TITLE
pubsub middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ You only need to set the environment variables for the services you want to use.
 
 note: application default credentials **can** be used for authentication.
 
+##### optional bigquery environment variables
+- `pubsub_bad_topic`: if exists, any transient failures or failed inserts will be published on this topic.
+
 ### [PUBSUB] Required Environment Variables
 - `pubsub_project`: Your PubSub project ID.
 - `pubsub_service_account_email`: Your PubSub service account email.
@@ -79,6 +82,7 @@ note: application default credentials **can** be used for authentication.
 #### optional pubsub environment variables
 - `pubsub_good_topic`: if exists, will publish messages for ALL rows (events/users/groups) to this topic; if this variable is NOT set, messages will be published to to each topic `EVENTS_TABLE_NAME`, `USERS_TABLE_NAME`, `GROUPS_TABLE_NAME`  based on the type of incoming request
 - `pubsub_bad_topic`: if exists, any transient failures or failed inserts will be published on this topic.
+
 
 
 #### [SNOWFLAKE] Required Environment Variables

--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ You only need to set the environment variables for the services you want to use.
 
 note: application default credentials **can** be used for authentication.
 
+### [PUBSUB] Required Environment Variables
+- `pubsub_project`: Your PubSub project ID.
+- `pubsub_service_account_email`: Your PubSub service account email.
+- `pubsub_service_account_private_key`: Your PubSub service account private key.
+- `pubsub_keyfile`: Path to your PubSub keyfile.
+
+note: application default credentials **can** be used for authentication.
+
+#### optional pubsub environment variables
+- `pubsub_good_topic`: if exists, will publish messages for ALL rows (events/users/groups) to this topic; if this variable is NOT set, messages will be published to to each topic `EVENTS_TABLE_NAME`, `USERS_TABLE_NAME`, `GROUPS_TABLE_NAME`  based on the type of incoming request
+- `pubsub_bad_topic`: if exists, any transient failures or failed inserts will be published on this topic.
+
+
 #### [SNOWFLAKE] Required Environment Variables
 - `snowflake_account`: Your Snowflake account name.
 - `snowflake_user`: Your Snowflake username.

--- a/components/validate.js
+++ b/components/validate.js
@@ -134,10 +134,25 @@ function validate(PARAMS = { ...process.env }) {
 		azure_connection_string = ""
 	} = PARAMS;
 
+	// PUBSUB
+	const {
+		pubsub_project = "",
+		pubsub_keyfile = "",
+		pubsub_service_account_email = "",
+		pubsub_service_account_private_key = "",
+		pubsub_good_topic = "",
+		pubsub_bad_topic = "",
+	} = PARAMS;
+
 	// bigquery
 	if (TARGETS.includes('BIGQUERY')) {
 		if (!bigquery_project) errors.push(new Error('bigquery_project is required'));
 		if (!bigquery_dataset) errors.push(new Error('bigquery_dataset is required'));
+	}
+
+	// pubsub
+	if (TARGETS.includes('PUBSUB')) {
+		if (!pubsub_project) errors.push(new Error('pubsub_project is required'));
 	}
 
 	// snowflake

--- a/middleware/bigquery.js
+++ b/middleware/bigquery.js
@@ -10,6 +10,7 @@ const { BigQuery } = require("@google-cloud/bigquery");
 /** @typedef { import('../types.js').BigQueryTypes } BQTypes */
 /** @typedef {import('@google-cloud/bigquery').BigQuery} BQClient */
 
+const pubsub = require("./pubsub.js");
 
 const NODE_ENV = process.env.NODE_ENV || "prod";
 const u = require("ak-tools");
@@ -43,6 +44,8 @@ let bigquery_service_account_private_key;
 let isClientReady;
 let isDatasetReady;
 let areTablesReady;
+let isPubSubReady;
+let pubsub_bad_topic;
 
 
 
@@ -90,8 +93,15 @@ async function main(data, type, tableNames) {
 
 async function initializeBigQuery(tableNames) {
 	// ENV STUFF
-	({ bigquery_dataset = "", bigquery_project, bigquery_keyfile, bigquery_service_account_email, bigquery_service_account_private_key } =
-		process.env);
+	({
+		bigquery_dataset = "",
+		bigquery_project,
+		bigquery_keyfile,
+		bigquery_service_account_email,
+		bigquery_service_account_private_key,
+		pubsub_bad_topic = ""
+
+	} = process.env);
 	const { eventTable, userTable, groupTable } = tableNames;
 	if (!isClientReady) {
 		isClientReady = await verifyBigQueryCredentials();
@@ -107,6 +117,15 @@ async function initializeBigQuery(tableNames) {
 		const tableCheckResults = await verifyOrCreateTables([["track", eventTable], ["user", userTable], ["group", groupTable]]);
 		areTablesReady = tableCheckResults.every(result => result);
 		if (!areTablesReady) throw new Error("Table verification or creation failed.");
+	}
+
+	const ready = [isClientReady, isDatasetReady, areTablesReady];
+
+	// ! PUBSUB FALLBACK INITIALIZATION
+	if (pubsub_bad_topic) {
+		const pubsubInit = await pubsub.init(pubsub_bad_topic);
+		isPubSubReady = true;
+		ready.push(isPubSubReady);
 	}
 
 	return [isClientReady, isDatasetReady, areTablesReady];
@@ -305,7 +324,21 @@ async function insertData(batch, table, schema) {
 		}
 
 		else {
-			throw error;
+			if (pubsub_bad_topic) {
+				const message = {
+					table: table.id,
+					error: error.message,
+					data: batch,
+					schema: schema,
+				};
+				const pubsubResult = await pubsub.publish(message, pubsub_bad_topic);
+				log(`[BIGQUERY] insert error; published to topic ${pubsub_bad_topic}; message id: ${pubsubResult?.messageId}`);
+			}
+
+			else {
+				throw error;
+			}
+			
 		}
 
 

--- a/middleware/bigquery.js
+++ b/middleware/bigquery.js
@@ -321,6 +321,16 @@ async function insertData(batch, table, schema) {
 
 			};
 			log(`[BIGQUERY] Partial failure`);
+			if (pubsub_bad_topic) {
+				const message = {
+					table: table.id,
+					error: error.name,
+					data: error.errors,
+					schema: schema,
+				};
+				const pubsubResult = await pubsub.publish(message, pubsub_bad_topic);
+				log(`[BIGQUERY] insert error; published to topic ${pubsub_bad_topic}; message id: ${pubsubResult?.messageId}`);
+			}
 		}
 
 		else {

--- a/middleware/bigquery.js
+++ b/middleware/bigquery.js
@@ -4,6 +4,8 @@ BIGQUERY MIDDLEWARE
 ----
 */
 
+//todo: pubsub fallback
+
 const { BigQuery } = require("@google-cloud/bigquery");
 /** @typedef { import('../types.js').BigQueryTypes } BQTypes */
 /** @typedef {import('@google-cloud/bigquery').BigQuery} BQClient */

--- a/middleware/bigquery.js
+++ b/middleware/bigquery.js
@@ -325,7 +325,9 @@ async function insertData(batch, table, schema) {
 				const message = {
 					table: table.id,
 					error: error.name,
-					data: error.errors,
+					kind: error.response?.kind,
+					data: batch,
+					details: error.errors,
 					schema: schema,
 				};
 				const pubsubResult = await pubsub.publish(message, pubsub_bad_topic);

--- a/middleware/pubsub.js
+++ b/middleware/pubsub.js
@@ -4,14 +4,10 @@ PUBSUB MIDDLEWARE
 ----
 */
 
-//todo: testing + types
-
 const { PubSub } = require("@google-cloud/pubsub");
 /** @typedef {import('@google-cloud/pubsub').PubSub} PubSubClient */
 
 const NODE_ENV = process.env.NODE_ENV || "prod";
-const u = require("ak-tools");
-// const { schematizeForWarehouse } = require('../components/transforms.js');
 const { insertWithRetry } = require("../components/retries.js");
 const log = require("../components/logger.js");
 
@@ -24,8 +20,14 @@ if (NODE_ENV === 'test') {
 /** @typedef {import('../types').Entities} Entities */
 /** @typedef {import('../types').Endpoints} Endpoints */
 /** @typedef {import('../types').TableNames} TopicNames */
-/** @typedef {import('../types').PubSubMessage} PubSubMessage */
-/** @typedef {import('../types').PublishResult} PublishResult */
+/** @typedef {Object} PubSubMessage */
+
+/** 
+ * @typedef {Object} PublishResult 
+ * @property {string} [status]
+ * @property {string} [messageId]
+ * @property {number} [timestamp]
+ */
 
 // these vars should be cached and only run once when the server starts
 /** @type {PubSubClient} */
@@ -232,5 +234,6 @@ async function dropTopics(topicNames) {
 
 main.drop = dropTopics;
 main.init = initializePubSub;
+main.publish = publishMessage;
 
 module.exports = main;

--- a/middleware/pubsub.js
+++ b/middleware/pubsub.js
@@ -1,0 +1,216 @@
+/*
+----
+PUBSUB MIDDLEWARE
+----
+*/
+
+//todo: testing + types
+
+const { PubSub } = require("@google-cloud/pubsub");
+/** @typedef {import('@google-cloud/pubsub').PubSub} PubSubClient */
+
+const NODE_ENV = process.env.NODE_ENV || "prod";
+const u = require("ak-tools");
+// const { schematizeForWarehouse } = require('../components/transforms.js');
+const { insertWithRetry } = require("../components/retries.js");
+const log = require("../components/logger.js");
+
+if (NODE_ENV === 'test') {
+	log.verbose(true);
+	log.cli(true);
+}
+
+// CORE MIDDLEWARE CONTRACT
+/** @typedef {import('../types').Entities} Entities */
+/** @typedef {import('../types').Endpoints} Endpoints */
+/** @typedef {import('../types').TableNames} TopicNames */
+/** @typedef {import('../types').PubSubMessage} PubSubMessage */
+/** @typedef {import('../types').PublishResult} PublishResult */
+
+// these vars should be cached and only run once when the server starts
+/** @type {PubSubClient} */
+let client;
+
+let pubsub_project;
+let pubsub_keyfile;
+let pubsub_service_account_email;
+let pubsub_service_account_private_key;
+let isClientReady;
+let areTopicsReady;
+
+/**
+ * Main function to handle Pub/Sub message publishing
+ * this function is called in the main server.js file
+ * and will be called repeatedly as clients stream data in (from client-side SDKs)
+ * @param  {PubSubMessage} data
+ * @param  {Endpoints} type
+ * @param  {TopicNames} topicNames
+ * @return {Promise<PublishResult>}
+ */
+async function main(data, type, topicNames) {
+	const startTime = Date.now();
+	const init = await initializePubSub(topicNames);
+
+	if (!init.every(i => i)) throw new Error("Failed to initialize Pub/Sub middleware.");
+
+	const { eventTable: eventTopic, userTable: userTopic, groupTable: groupTopic } = topicNames;
+	let targetTopic;
+
+	switch (type) {
+		case "track":
+			targetTopic = eventTopic;
+			break;
+		case "engage":
+			targetTopic = userTopic;
+			break;
+		case "groups":
+			targetTopic = groupTopic;
+			break;
+		default:
+			throw new Error("Invalid Record Type");
+	}
+
+	// @ts-ignore
+	const result = await insertWithRetry(publishMessage, data, targetTopic);
+	const duration = Date.now() - startTime;
+	result.duration = duration;
+
+	return result;
+}
+
+async function initializePubSub(topicNames) {
+	// ENV STUFF
+	({ pubsub_project, pubsub_keyfile, pubsub_service_account_email, pubsub_service_account_private_key } =
+		process.env);
+	const { eventTable: eventTopic, userTable: userTopic, groupTable: groupTopic } = topicNames;
+
+	if (!isClientReady) {
+		isClientReady = await verifyPubSubCredentials();
+		if (!isClientReady) throw new Error("Pub/Sub credentials verification failed.");
+	}
+
+	if (!areTopicsReady) {
+		const topicCheckResults = await verifyOrCreateTopics([eventTopic, userTopic, groupTopic]);
+		areTopicsReady = topicCheckResults.every(result => result);
+		if (!areTopicsReady) throw new Error("Topic verification or creation failed.");
+	}
+
+	return [isClientReady, areTopicsReady];
+}
+
+async function verifyPubSubCredentials() {
+	// credentials or keyfile or application default credentials
+	/** @type {import('@google-cloud/pubsub').ClientConfig} */
+	const auth = {};
+
+	if (pubsub_keyfile) {
+		auth.keyFilename = pubsub_keyfile;
+	}
+	if (pubsub_project) auth.projectId = pubsub_project;
+
+	if (pubsub_service_account_email && pubsub_service_account_private_key) {
+		auth.credentials = {
+			client_email: pubsub_service_account_email,
+			private_key: pubsub_service_account_private_key,
+		};
+	}
+
+	client = new PubSub(auth);
+
+	try {
+		await client.getTopics(); // Simple request to verify client setup
+		log("[PUBSUB] credentials are valid");
+		return true;
+	} catch (error) {
+		log("[PUBSUB] Error verifying Pub/Sub credentials:", error);
+		return false;
+	}
+}
+
+/**
+ * @param {string[]} topicNames
+ */
+async function verifyOrCreateTopics(topicNames) {
+	const results = [];
+
+	const [topics] = await client.getTopics();
+	const topicIds = topics.map(topic => topic.name.split('/').pop());
+
+	for (const topic of topicNames) {
+		if (!topicIds.includes(topic)) {
+			log(`[PUBSUB] Topic ${topic} does not exist. Creating...`);
+			await client.createTopic(topic);
+
+			const [updatedTopics] = await client.getTopics();
+			const updatedTopicIds = updatedTopics.map(t => t.name.split('/').pop());
+
+			if (updatedTopicIds.includes(topic)) {
+				log(`[PUBSUB] Topic ${topic} created.`);
+				results.push(true);
+			} else {
+				log(`[PUBSUB] Failed to create topic ${topic}`);
+				results.push(false);
+			}
+		} else {
+			log(`[PUBSUB] Topic ${topic} already exists.`);
+			results.push(true);
+		}
+	}
+
+	return results;
+}
+
+/**
+ * Publishes a message to a Pub/Sub topic
+ * @param  {PubSubMessage} message
+ * @param  {string} topicName
+ * @return {Promise<PublishResult>}
+ */
+async function publishMessage(message, topicName) {
+	log("[PUBSUB] Starting message publishing...");
+
+	const topic = client.topic(topicName);
+	let result = { status: "born" };
+
+	try {
+		const dataBuffer = Buffer.from(JSON.stringify(message));
+		const messageId = await topic.publishMessage({ data: dataBuffer });
+		result = { status: "success", messageId };
+	} catch (error) {
+		if (NODE_ENV === 'test') debugger;
+
+		log(`[PUBSUB] Error publishing message to topic ${topicName}:`, error);
+		result = {
+			status: "error",
+			error: error.message
+		};
+	}
+
+	log("[PUBSUB] Message publishing complete.");
+	return { ...result };
+}
+
+/**
+ * Drops all specified Pub/Sub topics... this is a destructive operation
+ * @param  {TopicNames} topicNames
+ */
+async function dropTopics(topicNames) {
+	log("[PUBSUB] Dropping all topics...");
+
+	const { eventTable: eventTopic, userTable: userTopic, groupTable: groupTopic } = topicNames;
+	const topicsToDrop = [eventTopic, userTopic, groupTopic];
+	const dropPromises = topicsToDrop.map(async (topicName) => {
+		const topic = client.topic(topicName);
+		await topic.delete();
+		log(`[PUBSUB] Dropped topic: ${topicName}`);
+	});
+
+	await Promise.all(dropPromises);
+	log(`[PUBSUB] Dropped ${topicsToDrop.length} topics: ${topicsToDrop.join(", ")}`);
+	return { numTopicsDropped: topicsToDrop.length, topicsDropped: topicsToDrop };
+}
+
+main.drop = dropTopics;
+main.init = initializePubSub;
+
+module.exports = main;

--- a/middleware/pubsub.js
+++ b/middleware/pubsub.js
@@ -41,6 +41,7 @@ let isClientReady;
 let areTopicsReady;
 let pubsub_good_topic;
 let pubsub_bad_topic;
+let bigquery_project;
 
 /**
  * Main function to handle Pub/Sub message publishing
@@ -92,11 +93,15 @@ async function initializePubSub(topicNames) {
 		pubsub_service_account_email,
 		pubsub_service_account_private_key,
 		pubsub_good_topic,
-		pubsub_bad_topic
+		pubsub_bad_topic,
+		bigquery_project,
 	} = process.env
 	);
 	const { eventTable: eventTopic, userTable: userTopic, groupTable: groupTopic } = topicNames;
 
+	// if pubsub_project is not set, use bigquery_project (if set)
+	if (!pubsub_project && bigquery_project) pubsub_project = bigquery_project;
+	
 	if (!pubsub_project) throw new Error("Pub/Sub project ID not set.");
 
 	if (!isClientReady) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@azure/storage-blob": "^12.18.0",
 				"@google-cloud/bigquery": "^7.7.0",
 				"@google-cloud/functions-framework": "^3.4.0",
+				"@google-cloud/pubsub": "^4.5.0",
 				"@google-cloud/storage": "^7.11.1",
 				"ak-tools": "^1.0.64",
 				"azure-function-express": "^2.0.0",
@@ -3282,6 +3283,46 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@google-cloud/pubsub": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-4.5.0.tgz",
+			"integrity": "sha512-ptRLLDrAp1rStD1n3ZrG8FdAfpccqI6M5rCaceF6PL7DU3hqJbvQ2Y91G8MKG7c7zK+jiWv655Qf5r2IvjTzwA==",
+			"dependencies": {
+				"@google-cloud/paginator": "^5.0.0",
+				"@google-cloud/precise-date": "^4.0.0",
+				"@google-cloud/projectify": "^4.0.0",
+				"@google-cloud/promisify": "^4.0.0",
+				"@opentelemetry/api": "~1.8.0",
+				"@opentelemetry/semantic-conventions": "~1.21.0",
+				"arrify": "^2.0.0",
+				"extend": "^3.0.2",
+				"google-auth-library": "^9.3.0",
+				"google-gax": "^4.3.3",
+				"heap-js": "^2.2.0",
+				"is-stream-ended": "^0.1.4",
+				"lodash.snakecase": "^4.1.1",
+				"p-defer": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@google-cloud/pubsub/node_modules/@opentelemetry/api": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+			"integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@google-cloud/pubsub/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.21.0.tgz",
+			"integrity": "sha512-lkC8kZYntxVKr7b8xmjCVUgE0a8xgDakPyDo9uSWavXPyYqLgYYGdEd2j8NxihRyb6UwpX3G/hFUF4/9q2V+/g==",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@google-cloud/storage": {
 			"version": "7.11.1",
 			"resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.11.1.tgz",
@@ -3340,10 +3381,9 @@
 			}
 		},
 		"node_modules/@grpc/grpc-js": {
-			"version": "1.10.8",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.8.tgz",
-			"integrity": "sha512-vYVqYzHicDqyKB+NQhAc54I1QWCBLCrYG6unqOIcBTHx+7x8C9lcoLj3KVJXs2VB4lUbpWY+Kk9NipcbXYWmvg==",
-			"dev": true,
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz",
+			"integrity": "sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==",
 			"dependencies": {
 				"@grpc/proto-loader": "^0.7.13",
 				"@js-sdsl/ordered-map": "^4.4.2"
@@ -3356,7 +3396,6 @@
 			"version": "0.7.13",
 			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
 			"integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
-			"dev": true,
 			"dependencies": {
 				"lodash.camelcase": "^4.3.0",
 				"long": "^5.0.0",
@@ -3740,7 +3779,6 @@
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
 			"integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-			"dev": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/js-sdsl"
@@ -4775,32 +4813,27 @@
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"dev": true
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
 		},
 		"node_modules/@protobufjs/base64": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"dev": true
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
 		},
 		"node_modules/@protobufjs/codegen": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-			"dev": true
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
 		},
 		"node_modules/@protobufjs/eventemitter": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-			"dev": true
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
 		},
 		"node_modules/@protobufjs/fetch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
 			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-			"dev": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.1",
 				"@protobufjs/inquire": "^1.1.0"
@@ -4809,32 +4842,27 @@
 		"node_modules/@protobufjs/float": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"dev": true
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
 		},
 		"node_modules/@protobufjs/inquire": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-			"dev": true
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
 		},
 		"node_modules/@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"dev": true
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
 		},
 		"node_modules/@protobufjs/pool": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"dev": true
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
 		},
 		"node_modules/@protobufjs/utf8": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-			"dev": true
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
 		},
 		"node_modules/@puppeteer/browsers": {
 			"version": "2.2.3",
@@ -5890,6 +5918,11 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/long": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+			"integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+		},
 		"node_modules/@types/mime": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -6300,7 +6333,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6309,7 +6341,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -7906,7 +7937,6 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -7991,7 +8021,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -8789,8 +8818,7 @@
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"node_modules/enabled": {
 			"version": "2.0.0",
@@ -9000,7 +9028,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
 			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -9779,7 +9806,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
@@ -9992,6 +10018,40 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/google-gax": {
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.3.9.tgz",
+			"integrity": "sha512-tcjQr7sXVGMdlvcG25wSv98ap1dtF4Z6mcV0rztGIddOcezw4YMb/uTXg72JPrLep+kXcVjaJjg6oo3KLf4itQ==",
+			"dependencies": {
+				"@grpc/grpc-js": "^1.10.9",
+				"@grpc/proto-loader": "^0.7.13",
+				"@types/long": "^4.0.0",
+				"abort-controller": "^3.0.0",
+				"duplexify": "^4.0.0",
+				"google-auth-library": "^9.3.0",
+				"node-fetch": "^2.7.0",
+				"object-hash": "^3.0.0",
+				"proto3-json-serializer": "^2.0.2",
+				"protobufjs": "^7.3.2",
+				"retry-request": "^7.0.0",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/google-gax/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/google-protobuf": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.6.1.tgz",
@@ -10136,6 +10196,14 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/heap-js": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.5.0.tgz",
+			"integrity": "sha512-kUGoI3p7u6B41z/dp33G6OaL7J4DRqRYwVmeIlwLClx7yaaAy7hoDExnuejTKtuDwfcatGmddHDEOjf6EyIxtQ==",
+			"engines": {
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/hex2dec": {
@@ -10626,7 +10694,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -10727,6 +10794,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/is-stream-ended": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+			"integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
 		},
 		"node_modules/is-typed-array": {
 			"version": "1.1.13",
@@ -11855,8 +11927,7 @@
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-			"dev": true
+			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
 		},
 		"node_modules/lodash.defaults": {
 			"version": "4.2.0",
@@ -11916,6 +11987,11 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
 			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+		},
+		"node_modules/lodash.snakecase": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
 		},
 		"node_modules/lodash.union": {
 			"version": "4.6.0",
@@ -12038,8 +12114,7 @@
 		"node_modules/long": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-			"integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-			"dev": true
+			"integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
 		},
 		"node_modules/lowercase-keys": {
 			"version": "2.0.0",
@@ -12683,6 +12758,14 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
+		"node_modules/object-hash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/object-inspect": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -12806,6 +12889,14 @@
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
 			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-defer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+			"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
 			"engines": {
 				"node": ">=8"
 			}
@@ -13352,11 +13443,21 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/proto3-json-serializer": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+			"integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+			"dependencies": {
+				"protobufjs": "^7.2.5"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/protobufjs": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-			"integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
-			"dev": true,
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+			"integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
@@ -13857,7 +13958,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -14845,7 +14945,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -14873,7 +14972,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -15787,7 +15885,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -15873,7 +15970,6 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -15894,7 +15990,6 @@
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -15912,7 +16007,6 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
 			"engines": {
 				"node": ">=12"
 			}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"@azure/storage-blob": "^12.18.0",
 		"@google-cloud/bigquery": "^7.7.0",
 		"@google-cloud/functions-framework": "^3.4.0",
+		"@google-cloud/pubsub": "^4.5.0",
 		"@google-cloud/storage": "^7.11.1",
 		"ak-tools": "^1.0.64",
 		"azure-function-express": "^2.0.0",

--- a/server.js
+++ b/server.js
@@ -38,13 +38,14 @@ const log = require('./components/logger');
 
 // MIDDLEWARE
 const bigquery = require('./middleware/bigquery');
+const pubsub = require('./middleware/pubsub');
 const snowflake = require('./middleware/snowflake');
 const redshift = require('./middleware/redshift');
 const mixpanel = require('./middleware/mixpanel');
 const gcs = require('./middleware/gcs');
 const s3 = require('./middleware/s3');
 const azure = require('./middleware/azure');
-const middleware = { bigquery, snowflake, redshift, mixpanel, gcs, s3, azure };
+const middleware = { bigquery, pubsub, snowflake, redshift, mixpanel, gcs, s3, azure };
 const middlewareList = Object.keys(middleware).map(m => m.toLowerCase());
 
 

--- a/tests/int.test.js
+++ b/tests/int.test.js
@@ -19,7 +19,8 @@ const mixpanel = require('../middleware/mixpanel');
 const gcs = require('../middleware/gcs');
 const s3 = require('../middleware/s3');
 const azure = require('../middleware/azure');
-const middleware = { bigquery, snowflake, redshift, mixpanel, gcs, s3, azure };
+const pubsub = require('../middleware/pubsub');
+const middleware = { bigquery, snowflake, redshift, mixpanel, gcs, s3, azure, pubsub };
 
 
 const timeout = 60000;
@@ -194,7 +195,6 @@ describe('GCS', () => {
 	}, timeout);
 });
 
-
 describe('S3', () => {
 
 	test('s3: events', async () => {
@@ -247,4 +247,28 @@ describe('Azure', () => {
 		expect(insertedRows).toBe(1);
 		expect(status).toBe('success');
 	}, timeout);
+});
+
+describe('PubSub', () => {
+
+    test('pubsub: events', async () => {
+        const result = await pubsub(e, 'track', tableNames);
+        const {  insertedRows, status } = result;
+        expect(insertedRows).toBe(1);
+        expect(status).toBe('success');
+    }, timeout);
+
+    test('pubsub: users', async () => {
+        const result = await pubsub(u, 'engage', tableNames);
+        const {  insertedRows, status } = result;
+        expect(insertedRows).toBe(1);
+        expect(status).toBe('success');
+    }, timeout);
+
+    test('pubsub: groups', async () => {
+        const result = await pubsub(g, 'groups', tableNames);
+        const {  insertedRows, status } = result;
+        expect(insertedRows).toBe(1);
+        expect(status).toBe('success');
+    }, timeout);
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -186,6 +186,15 @@ export type BigQueryVars = {
   bigquery_service_account_private_key: string;
 };
 
+
+export type PubSubVars = {
+	pubsub_project: string;
+	pubsub_keyfile: string;
+	pubsub_service_account_email: string;
+	pubsub_service_account_private_key: string;
+	pubsub_retry_topic: string;
+}
+
 export type SnowflakeVars = {
   snowflake_account: string;
   snowflake_user: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -186,14 +186,14 @@ export type BigQueryVars = {
   bigquery_service_account_private_key: string;
 };
 
-
 export type PubSubVars = {
-	pubsub_project: string;
-	pubsub_keyfile: string;
-	pubsub_service_account_email: string;
-	pubsub_service_account_private_key: string;
-	pubsub_retry_topic: string;
-}
+  pubsub_project: string;
+  pubsub_keyfile?: string;
+  pubsub_service_account_email?: string;
+  pubsub_service_account_private_key?: string;
+  pubsub_good_topic?: string;
+  pubsub_bad_topic?: string;
+};
 
 export type SnowflakeVars = {
   snowflake_account: string;
@@ -260,7 +260,7 @@ export type CommonVars = {
   USERS_TABLE_NAME: string;
   GROUPS_TABLE_NAME: string;
   TIMEOUT: number;
-  [key: string]: string
+  [key: string]: string;
 };
 
 export type EnvVars = BigQueryVars & SnowflakeVars & RedshiftVars & GCSVars & CommonVars;


### PR DESCRIPTION
this PR introduces a pubsub middleware that makes it possible to federate data received by the proxy (from the mixpanel SDK) through pubsub by pushing messages onto a predefined topic.

see docs on how to setup pubsub; it is similar to most all other middle-wares - the biggest difference in the API is that you can (optionally) supply a single topic `pubsub_good_topic` as an env variable _instead_ of broadcasting to specific topics (tables) for `events`, `users`, and `groups` (default).

this PR also introduces functionality where - when using `BigQuery` as a destination, if you set a `pubsub_bad_topic` env variable, any BigQuery inserts that fail (after `MAX_RETRIES`) will be sent as a pubsub message to that topic. this makes the bigquery pipeline more reliable, ensuring nothing gets dropped.

![bigquery tests](https://github.com/user-attachments/assets/06de409c-7e4a-4f2a-9331-c5227bc9edc7)
![pubsub tests](https://github.com/user-attachments/assets/8773c92a-6a33-4857-af01-27ef9a9108c3)
